### PR TITLE
Address warnings

### DIFF
--- a/blake2b/Makefile
+++ b/blake2b/Makefile
@@ -1,18 +1,24 @@
 IDIR = include
 ODIR = build
 BIN = bin
-CFLAGS = -I $(IDIR) -Wall -lm -g -std=c89 -Wc90-c99-compat -Wc99-c11-compat -pedantic
+CFLAGS = -I $(IDIR) -Wall -lm -g -Wc99-c11-compat -pedantic
 CC = gcc
 
 src = $(wildcard src/*.c)
 obj = $(patsubst src/%.c, $(ODIR)/%.o, $(src))
 out = blake2b
 
-blake: $(obj)
+blake: $(obj) | bin
 	$(CC) $(obj) -o $(BIN)/$(out) $(CFLAGS)
 
-$(ODIR)/%.o: src/%.c
+$(ODIR)/%.o: src/%.c | build
 	$(CC) -c $< -o $@ $(CFLAGS)
+
+bin:
+	mkdir $(BIN)
+
+build:
+	mkdir $(ODIR)
 
 clean:
 	rm -f $(wildcard $(ODIR)/*.o) $(wildcard *~) core  $(BIN)/$(out)*

--- a/blake2b/include/blake2b.h
+++ b/blake2b/include/blake2b.h
@@ -8,9 +8,9 @@
  * The BLAKE2b initialization vectors
  */
 static const uint64_t blake2b_IV[8] = {
-  0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b,
-  0xa54ff53a5f1d36f1, 0x510e527fade682d1, 0x9b05688c2b3e6c1f,
-  0x1f83d9abfb41bd6b, 0x5be0cd19137e2179
+  0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL,
+  0xa54ff53a5f1d36f1ULL, 0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL,
+  0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
 };
 
 /**

--- a/blake2b/src/blake2b.c
+++ b/blake2b/src/blake2b.c
@@ -207,7 +207,7 @@ void
 blake2b_update(blake2b_state* state, const unsigned char* input_buffer,
                size_t inlen)
 {
-  unsigned char* in = input_buffer;
+  const unsigned char* in = input_buffer;
   size_t left = state->buflen;
   size_t fill = BLAKE2B_BLOCKBYTES - left;
   if (inlen > fill) {


### PR DESCRIPTION
Create build and bin directories through order-only prereq
Add ULL to initialization vectors to make it unsigned long long
Remove irrelevant std-c89 and compat flags
Add constness to pointer to input buffer